### PR TITLE
Add 17.06.0-ce as an available build image to use.

### DIFF
--- a/17.06.0-ce-1.0.8/Dockerfile
+++ b/17.06.0-ce-1.0.8/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker:17.06.0-ce
+
+RUN apk add --no-cache python py-pip \
+    && pip install --disable-pip-version-check --no-cache-dir docker-cloud==1.0.8


### PR DESCRIPTION
Adds docker `17.06.0-ce` as an available docker version. The idea would not be to change the latest tag as docker-cloud doesn't officially support 17.06.0 yet. 